### PR TITLE
Enum support

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,8 +7,9 @@
 -   [t]—test suite improvement
 -   [d]—docs improvement
 
+0.2.0-SNAPSHOT
+- [+] Added support for enums
+
 0.1.0 (Febuary 25, 2023)
 -   🎉 initial release.
 
-0.2.0-SNAPSHOT
-- [+] Added support for enums

--- a/changelog.md
+++ b/changelog.md
@@ -9,3 +9,6 @@
 
 0.1.0 (Febuary 25, 2023)
 -   🎉 initial release.
+
+0.2.0-SNAPSHOT
+- [+] Added support for enums

--- a/src/lowdb/postgres.nim
+++ b/src/lowdb/postgres.nim
@@ -113,7 +113,7 @@ proc dbValue*(v: DbValue): DbValue =
   ## Return ``v`` as is.
   v
 
-proc dbValue*(v: SomeOrdinal and not uint64): DbValue =
+proc dbValue*(v: SomeSignedInt | uint8 | uint16 | uint32 | enum): DbValue =
   ## Wrap integer value.
   DbValue(kind: dvkInt, i: v.int64)
 

--- a/src/lowdb/postgres.nim
+++ b/src/lowdb/postgres.nim
@@ -78,7 +78,7 @@ type
     dvkTimestamptz
     dvkOther
     dvkNull
-  DbValueTypes* = bool|int64|float64|string|DateTime|DbOther|DbNull ## Possible value types
+  DbValueTypes* = bool|int64|float64|enum|string|DateTime|DbOther|DbNull ## Possible value types
   DbOther* = object
     oid*: Oid
     value*: string
@@ -113,7 +113,7 @@ proc dbValue*(v: DbValue): DbValue =
   ## Return ``v`` as is.
   v
 
-proc dbValue*(v: int|int8|int16|int32|int64|uint8|uint16|uint32): DbValue =
+proc dbValue*(v: SomeOrdinal and not uint64): DbValue =
   ## Wrap integer value.
   DbValue(kind: dvkInt, i: v.int64)
 

--- a/src/lowdb/sqlite.nim
+++ b/src/lowdb/sqlite.nim
@@ -96,7 +96,7 @@ type
     dvkString ## SQLITE_TEXT, string
     dvkBlob   ## SQLITE_BLOB, BLOB
     dvkNull   ## SQLITE_NULL, NULL
-  DbValueTypes* = int64|float64|string|DbBlob|DbNull ## \
+  DbValueTypes* = int64|float64|enum|string|DbBlob|DbNull ## \
     ## Possible value types
   DbBlob* = distinct string ## SQLite BLOB value.
   DbNull* = object          ## SQLite NULL value.
@@ -194,7 +194,7 @@ proc dbValue*(v: DbValue): DbValue =
   ## Return ``v`` as is.
   v
 
-proc dbValue*(v: int|int8|int16|int32|int64|uint8|uint16|uint32): DbValue =
+proc dbValue*(v: SomeOrdinal and not uint64): DbValue =
   ## Wrap integer value.
   DbValue(kind: dvkInt, i: v.int64)
 

--- a/src/lowdb/sqlite.nim
+++ b/src/lowdb/sqlite.nim
@@ -194,7 +194,7 @@ proc dbValue*(v: DbValue): DbValue =
   ## Return ``v`` as is.
   v
 
-proc dbValue*(v: SomeOrdinal and not uint64): DbValue =
+proc dbValue*(v: SomeSignedInt | uint8 | uint16 | uint32 | enum): DbValue =
   ## Wrap integer value.
   DbValue(kind: dvkInt, i: v.int64)
 

--- a/tests/tpostgres.nim
+++ b/tests/tpostgres.nim
@@ -237,6 +237,15 @@ suite "various":
       n.inc
     check n == 2
     db.close()
+    
+  test "enum":
+    type
+      Foo = enum
+        A
+        B
+        C
+    let db = test_open()
+    check Foo(db.getRow(sql"SELECT $1", A).get()[0].i) == A
 
 #  test "instantRows()":
 #    let db = test_open()

--- a/tests/tsqlite.nim
+++ b/tests/tsqlite.nim
@@ -303,6 +303,15 @@ suite "various":
     db.exec sql"CREATE TABLE t1 (id SERIAL PRIMARY KEY, value TEXT)"
     let id = db.insertID sql"INSERT INTO t1(value) VALUES ('a')"
     check id == 1
+  
+  test "enum":
+    type
+      Foo = enum
+        A
+        B
+        C
+    let db = open(":memory", "", "", "")
+    check db.getValue(Foo, sql"SELECT ?", A).get() == A
 
 suite "Prepared statement finalization":
 


### PR DESCRIPTION
Enums are basically just fancy numbers and so conversion into the database will almost always be the same and so it makes sense to have support for them upstream in `lowdb` itself