### PR TITLE
Use `openArray` in internal procs

### DIFF
--- a/src/lowdb/postgres.nim
+++ b/src/lowdb/postgres.nim
@@ -220,7 +220,7 @@ proc dbError*(db: DbConn) {.noreturn.} =
   e.msg = $pqErrorMessage(db)
   raise e
 
-proc tryWithStmt(db: DbConn, query: SqlQuery, args: seq[DbValue],
+proc tryWithStmt(db: DbConn, query: SqlQuery, args: openArray[DbValue],
                  expectedStatusType: ExecStatusType,
                  body: proc(res: PPGresult): bool {.raises: [], tags: [], gcsafe.}): bool =
   ## A common template dealing with statement initialization and finalization:

--- a/src/lowdb/sqlite.nim
+++ b/src/lowdb/sqlite.nim
@@ -234,7 +234,7 @@ proc tryFinalize(stmt: Pstmt): bool {.raises: [].} =
 
 # Specific
 proc bindArgs(db: DbConn, stmt: var sqlite3.Pstmt, query: SqlQuery,
-              args: seq[DbValue]): bool {.raises: [].} =
+              args: openArray[DbValue]): bool {.raises: [].} =
   var idx: int32 = 0
   for arg in args:
     inc idx
@@ -242,7 +242,7 @@ proc bindArgs(db: DbConn, stmt: var sqlite3.Pstmt, query: SqlQuery,
       return false
   return true
 
-proc tryWithStmt(db: DbConn, query: SqlQuery, args: seq[DbValue],
+proc tryWithStmt(db: DbConn, query: SqlQuery, args: openArray[DbValue],
                  body: proc(stmt: Pstmt): bool {.raises: [], tags: [], gcsafe.}): bool =
   ## A common template dealing with statement initialization and finalization:
   ##
@@ -263,7 +263,7 @@ proc tryWithStmt(db: DbConn, query: SqlQuery, args: seq[DbValue],
     ok = tryFinalize(stmt) and ok
   ok
 
-template withStmt(db: DbConn, query: SqlQuery, args: seq[DbValue],
+template withStmt(db: DbConn, query: SqlQuery, args: openArray[DbValue],
                   body: untyped): untyped =
   ## A common template dealing with statement initialization and finalization:
   ##


### PR DESCRIPTION
Not a big change, just makes all the internal procs take an `openArray[T]` instead of `seq[T]`.

I've been needing to use the internal procs in [ponairi](https://github.com/ire4ever1190/ponairi) and its handy not having to convert arrays into seqs