### PR TITLE
The nimble file failed to import db_connector for nim version 2.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,9 @@
 -   [t]—test suite improvement
 -   [d]—docs improvement
 
+0.2.1 (August 06, 2023)
+- [f] Fixed db_connector not being imported for nim version 2.0.0
+
 0.2.0 (March 11, 2023)
 - [+] Added support for enums
 - [r] Refactored complete test-suite

--- a/lowdb.nimble
+++ b/lowdb.nimble
@@ -1,4 +1,4 @@
-version       = "0.2.0"
+version       = "0.2.1"
 author        = "Philipp Doerner" # Original Author of the package
 description   = "Low level db_sqlite and db_postgres forks with a proper typing"
 license       = "MIT"

--- a/lowdb.nimble
+++ b/lowdb.nimble
@@ -5,7 +5,7 @@ license       = "MIT"
 srcDir        = "src"
 
 requires "nim >= 1.4.0"
-when NimMajor >= 1 and NimMinor >= 9:
+when NimMajor == 2 or (NimMajor >= 1 and NimMinor >= 9):
   requires "db_connector >= 0.1.0"
 
 skipDirs = @["tests"]


### PR DESCRIPTION
The reason was that nim 2.0.0 of course does not fulfill the requirement of a minor version larger than 9, which is required for Nim 1.9