### PR TITLE
Remove the conditional dependency

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        nim-version: ['1.4.0', 'stable', 'devel']
+        nim-version: ['2.0.0', 'stable', 'devel']
 
     services:
       postgres:

--- a/lowdb.nimble
+++ b/lowdb.nimble
@@ -4,7 +4,7 @@ description   = "Low level db_sqlite and db_postgres forks with a proper typing"
 license       = "MIT"
 srcDir        = "src"
 
-requires "nim >= 2.0.0"
+requires "nim >= 1.7.3"
 requires "db_connector >= 0.1.0"
 
 skipDirs = @["tests"]

--- a/lowdb.nimble
+++ b/lowdb.nimble
@@ -1,12 +1,11 @@
-version       = "0.2.1"
+version       = "0.3.0"
 author        = "Philipp Doerner" # Original Author of the package
 description   = "Low level db_sqlite and db_postgres forks with a proper typing"
 license       = "MIT"
 srcDir        = "src"
 
-requires "nim >= 1.4.0"
-when NimMajor == 2 or (NimMajor >= 1 and NimMinor >= 9):
-  requires "db_connector >= 0.1.0"
+requires "nim >= 2.0.0"
+requires "db_connector >= 0.1.0"
 
 skipDirs = @["tests"]
 

--- a/lowdb.nimble
+++ b/lowdb.nimble
@@ -4,7 +4,7 @@ description   = "Low level db_sqlite and db_postgres forks with a proper typing"
 license       = "MIT"
 srcDir        = "src"
 
-requires "nim >= 1.7.3"
+requires "nim >= 2.0.0"
 requires "db_connector >= 0.1.0"
 
 skipDirs = @["tests"]


### PR DESCRIPTION
Have been getting this warning in latest devel Nim which leads to the package not getting installed
```
  Warning:  Declarative parser failed, the file had to be parsed with the VM parser. Please fix your nimble file.
  Warning:  /home/runner/.nimble/pkgs2/lowdb-0.2.1-e26a392547b826d7d3e6566dc0fd76e9f42ead06/lowdb.nimble(9, 2) 'requires' cannot be nested inside control flow statements
```
Latest Nimble enables the declarative parser by default which is causing lowdb to not be installed correctly since it doesn't like the structure. This removes the conditional and bumps to minimum Nim that `db_connector` (minimum is `1.7.3` which was a dev version, so made minimum `2.0.0` which was the next stable)